### PR TITLE
Add geo_scores_for_taxa endpoint

### DIFF
--- a/lib/inat_inferrer.py
+++ b/lib/inat_inferrer.py
@@ -426,15 +426,23 @@ class InatInferrer:
         return all_node_scores
 
     def h3_04_geo_results_for_taxon_and_cell(self, taxon_id, lat, lng):
+        if lat is None or lng is None:
+            return None
+        try:
+            lat_float = float(lat)
+            lng_float = float(lng)
+        except ValueError:
+            return None
+
         try:
             taxon = self.taxonomy.df.loc[taxon_id]
-        except:
+        except KeyError:
             return None
-            # print(f"taxon `{taxon_id}` does not exist in the taxonomy")
-            # raise e
-        if pd.isna(taxon["leaf_class_id"]):
+
+        if pd.isna(taxon["leaf_class_id"]) or pd.isna(taxon["geo_threshold"]):
             return None
-        h3_cell = h3.geo_to_h3(float(lat), float(lng), 4)
+
+        h3_cell = h3.geo_to_h3(lat_float, lng_float, 4)
         return float(self.geo_elevation_model.eval_one_class_elevation_from_features(
             [self.geo_model_features[self.geo_elevation_cell_indices[h3_cell]]],
             int(taxon["leaf_class_id"])

--- a/lib/inat_vision_api.py
+++ b/lib/inat_vision_api.py
@@ -28,6 +28,8 @@ class InatVisionAPI:
                               self.h3_04_taxon_range_comparison_route, methods=["GET"])
         self.app.add_url_rule("/h3_04_bounds", "h3_04_bounds",
                               self.h3_04_bounds_route, methods=["GET"])
+        self.app.add_url_rule("/geo_scores_for_taxa", "geo_scores_for_taxa",
+                              self.geo_scores_for_taxa_route, methods=["POST"])
         self.app.add_url_rule("/build_info", "build_info", self.build_info_route, methods=["GET"])
 
     def setup_inferrer(self, config):
@@ -84,6 +86,14 @@ class InatVisionAPI:
             "git_commit": os.getenv("GIT_COMMIT", ""),
             "image_tag": os.getenv("IMAGE_TAG", ""),
             "build_date": os.getenv("BUILD_DATE", "")
+        }
+
+    def geo_scores_for_taxa_route(self):
+        return {
+            obs["id"]: self.inferrer.h3_04_geo_results_for_taxon_and_cell(
+                obs["taxon_id"], obs["lat"], obs["lng"]
+            )
+            for obs in request.json["observations"]
         }
 
     def index_route(self):


### PR DESCRIPTION
Adds a geo_scores_for_taxa endpoint. It accepts an array of observations with taxon_id, lat, and lng, and returns the ratio of the raw geo model score and the taxon geo threshold