### PR TITLE
use centroids for geo prior inference

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -8,7 +8,6 @@ models:
     tf_elev_thresholds: "models/.../thresholds.csv"
     taxon_ranges_path: "models/.../taxon_ranges
     geo_min: 0.005
-    use_coord_encoder: False
   - name: "ModelGenerationName_coord_encoder"
     vision_model_path: "models/.../vision_model.h5"
     taxonomy_path: "models/.../taxonomy.csv"
@@ -17,9 +16,6 @@ models:
     tf_elev_thresholds: "models/.../thresholds.csv"
     taxon_ranges_path: "models/.../taxon_ranges
     geo_min: 0.005
-    use_coord_encoder: True
-    coord_encoder:
-        env_raster: "models/.../elev_scaled.npy"
-        encoding_strategy: "sinusoidal"
-        
+    coord_encoder_raster: "models/.../elev_scaled.npy"
+    use_raster_nearby: False
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -6,4 +6,20 @@ models:
     tf_geo_elevation_model_path: "models/.../tf_gpmodel.h5"
     elevation_h3_r4: "models/.../elevation_r4_5m.csv"
     tf_elev_thresholds: "models/.../thresholds.csv"
-    taxon_ranges_path: "models/.../taxon_ranges"
+    taxon_ranges_path: "models/.../taxon_ranges
+    geo_min: 0.005
+    use_coord_encoder: False
+  - name: "ModelGenerationName_coord_encoder"
+    vision_model_path: "models/.../vision_model.h5"
+    taxonomy_path: "models/.../taxonomy.csv"
+    tf_geo_elevation_model_path: "models/.../tf_gpmodel.h5"
+    elevation_h3_r4: "models/.../elevation_r4_5m.csv"
+    tf_elev_thresholds: "models/.../thresholds.csv"
+    taxon_ranges_path: "models/.../taxon_ranges
+    geo_min: 0.005
+    use_coord_encoder: True
+    coord_encoder:
+        env_raster: "models/.../elev_scaled.npy"
+        encoding_strategy: "sinusoidal"
+        
+

--- a/generate_thresholds.py
+++ b/generate_thresholds.py
@@ -21,6 +21,7 @@ def ignore_shapely_deprecation_warning(message, category, filename, lineno, file
         return None
     return warnings.defaultaction(message, category, filename, lineno, file, line)
 
+
 def _load_train_data_csv(path):
     print("loading in the training data from csv...")
     train_df = pd.read_csv(
@@ -34,11 +35,13 @@ def _load_train_data_csv(path):
     )
     return train_df
 
+
 def _load_train_data_parquet(path):
     print("loading in the training data from parquet...")
     train_df = pd.read_parquet(path)
     train_df = train_df[["taxon_id", "latitude", "longitude", "captive"]]
     return train_df
+
 
 def _load_train_data(path):
     if path.endswith(".csv"):
@@ -47,15 +50,14 @@ def _load_train_data(path):
         train_df = _load_train_data_parquet(path)
     else:
         assert False, "spatial data train df format not supported."
-    
+
     train_df.rename({
         "latitude": "lat",
         "longitude": "lng",
     }, axis=1, inplace=True)
-    train_df = train_df[train_df.captive==0] # no-CID ok, wild only
+    train_df = train_df[train_df.captive == 0]  # no-CID ok, wild only
     train_df.drop(["captive"], axis=1)
     return train_df
- 
 
 
 def main(args):
@@ -119,8 +121,8 @@ def main(args):
 
     # we want the taxon id to be the index since we'll be selecting on it
     train_df_h3.reset_index(inplace=True)
-    train_df_h3.set_index("taxon_id", inplace=True)    
-    
+    train_df_h3.set_index("taxon_id", inplace=True)
+
     print("...looping through taxa")
     for taxon_id in tqdm(taxon_ids):
         try:

--- a/lib/coord_encoder.py
+++ b/lib/coord_encoder.py
@@ -1,0 +1,119 @@
+import math
+
+import numpy as np
+import tensorflow as tf
+
+
+class CoordEncoder:
+    def __init__(self, encoding_strategy, raster=None):
+        assert encoding_strategy in [
+            "sinusoidal",
+        ], "unsupported encoding strategy"
+
+        self.encoding_strategy = encoding_strategy
+        
+        self.raster = raster
+
+    def encode(self, locs, normalize=True):
+        if normalize:
+            locs = CoordEncoder.normalize_coords(locs)
+        
+        if self.encoding_strategy == "sinusoidal":
+            loc_feats = CoordEncoder.encode_loc_sinusoidal(locs)
+        else:
+            assert False, "unsupported encoding strategy"
+        
+        if self.raster is not None:
+            context_feats = CoordEncoder.bilinear_interpolate(locs, self.raster)
+            loc_feats = np.concatenate((loc_feats, context_feats), 1)
+
+        return loc_feats
+
+    def num_input_feats(self):
+        if self.encoding_strategy == "sinusoidal":
+            coord_feats = 4
+        else:
+            assert False, "unsupported encoding strategy"
+
+        if self.raster is not None:
+            return coord_feats + self.raster.shape[-1]
+        else:
+            return coord_feats
+
+    @staticmethod
+    def normalize_coords(locs):
+        return tf.stack([
+            locs[:, 0] / 180.0,
+            locs[:, 1] / 90.0,
+        ], axis=1)
+
+    @staticmethod
+    def encode_loc_sinusoidal(loc_ip, concat_dim=1):
+        return tf.concat([
+            tf.sin(loc_ip * math.pi),
+            tf.cos(loc_ip * math.pi),
+        ], axis=concat_dim)
+
+   
+    @staticmethod
+    def bilinear_interpolate(loc_ip, data, remove_nans_raster=True):
+        """
+        Perform bilinear interpolation on a raster using normalized 
+        [-1, 1] lng, lat input.
+        
+        Args:
+            loc_ip: [N x 2] tensor/array of [lng, lat] in [-1, 1] space
+            data: [H x W x C] raster data
+            remove_nans_raster: whether to replace NaNs in `data` with 0.0
+        
+        Returns:
+            np.ndarray: [N x C] interpolated feats for each location
+        """
+        assert data is not None
+        assert loc_ip.shape[1] == 2
+        
+        if remove_nans_raster:
+            data = np.nan_to_num(data, nan=0.0)
+        
+        # normalize from [-1, 1] to [0, 1]
+        loc = (loc_ip + 1.0) / 2.0
+
+        # flip y-axis for raster top down layout
+        x = loc[:, 0]
+        y = 1.0 - loc[:, 1]
+    
+        # convert to pixel indices
+        px = x * (data.shape[1] - 1)
+        py = y * (data.shape[0] - 1)
+    
+        # corner integer indices
+        x0 = tf.floor(px).numpy().astype(int)
+        y0 = tf.floor(py).numpy().astype(int)
+        x1 = np.clip(x0 + 1, 0, data.shape[1] - 1)
+        y1 = np.clip(y0 + 1, 0, data.shape[0] - 1)
+
+        # deltas for interpolation
+        dx = np.expand_dims(px - x0, axis=1)
+        dy = np.expand_dims(py - y0, axis=1)
+
+        # fetch corner values
+        top_left             = data[y0, x0, :]
+        top_right            = data[y0, x1, :]
+        bottom_left          = data[y1, x0, :]
+        bottom_right         = data[y1, x1, :]
+        
+        # bilinear interpolation
+        interp_value = (
+            top_left * (1 - dx) * (1 - dy) +
+            top_right * dx * (1 - dy) + 
+            bottom_left * (1 - dx) * dy +
+            bottom_right * dx * dy
+        )
+
+        return interp_value
+
+
+
+
+
+

--- a/lib/coord_encoder.py
+++ b/lib/coord_encoder.py
@@ -5,40 +5,71 @@ import tensorflow as tf
 
 
 class CoordEncoder:
-    def __init__(self, encoding_strategy, raster=None):
-        assert encoding_strategy in [
-            "sinusoidal",
-        ], "unsupported encoding strategy"
+    def __init__(self, raster):
+        assert raster is not None
+        self.raster = np.nan_to_num(raster, nan=0.0)
 
-        self.encoding_strategy = encoding_strategy
-        
-        self.raster = raster
+    def encode(self, locs):
+        locs = CoordEncoder.normalize_coords(locs)
 
-    def encode(self, locs, normalize=True):
-        if normalize:
-            locs = CoordEncoder.normalize_coords(locs)
-        
-        if self.encoding_strategy == "sinusoidal":
-            loc_feats = CoordEncoder.encode_loc_sinusoidal(locs)
-        else:
-            assert False, "unsupported encoding strategy"
-        
-        if self.raster is not None:
-            context_feats = CoordEncoder.bilinear_interpolate(locs, self.raster)
-            loc_feats = np.concatenate((loc_feats, context_feats), 1)
+        loc_feats = CoordEncoder.encode_loc_sinusoidal(locs)
+
+        context_feats = self.bilinear_interpolate(locs)
+        loc_feats = np.concatenate((loc_feats, context_feats), 1)
 
         return loc_feats
 
-    def num_input_feats(self):
-        if self.encoding_strategy == "sinusoidal":
-            coord_feats = 4
-        else:
-            assert False, "unsupported encoding strategy"
+    def bilinear_interpolate(self, loc_ip):
+        """
+        Perform bilinear interpolation on a raster using normalized
+        [-1, 1] lng, lat input.
 
-        if self.raster is not None:
-            return coord_feats + self.raster.shape[-1]
-        else:
-            return coord_feats
+        Args:
+            loc_ip: [N x 2] tensor/array of [lng, lat] in [-1, 1] space
+            data: [H x W x C] raster data
+            remove_nans_raster: whether to replace NaNs in `data` with 0.0
+
+        Returns:
+            np.ndarray: [N x C] interpolated feats for each location
+        """
+        assert loc_ip.shape[1] == 2
+
+        # normalize from [-1, 1] to [0, 1]
+        loc = (loc_ip + 1.0) / 2.0
+
+        # flip y-axis for raster top down layout
+        x = loc[:, 0]
+        y = 1.0 - loc[:, 1]
+
+        # convert to pixel indices
+        px = x * (self.raster.shape[1] - 1)
+        py = y * (self.raster.shape[0] - 1)
+
+        # corner integer indices
+        x0 = tf.floor(px).numpy().astype(int)
+        y0 = tf.floor(py).numpy().astype(int)
+        x1 = np.clip(x0 + 1, 0, self.raster.shape[1] - 1)
+        y1 = np.clip(y0 + 1, 0, self.raster.shape[0] - 1)
+
+        # deltas for interpolation
+        dx = np.expand_dims(px - x0, axis=1)
+        dy = np.expand_dims(py - y0, axis=1)
+
+        # fetch corner values
+        top_left = self.raster[y0, x0, :]
+        top_right = self.raster[y0, x1, :]
+        bottom_left = self.raster[y1, x0, :]
+        bottom_right = self.raster[y1, x1, :]
+
+        # bilinear interpolation
+        interp_value = (
+            (top_left * (1 - dx) * (1 - dy)) +  # noqa: W504
+            (top_right * dx * (1 - dy)) +   # noqa: W504
+            (bottom_left * (1 - dx) * dy) +  # noqa: W504
+            (bottom_right * dx * dy)
+        )
+
+        return interp_value
 
     @staticmethod
     def normalize_coords(locs):
@@ -48,72 +79,8 @@ class CoordEncoder:
         ], axis=1)
 
     @staticmethod
-    def encode_loc_sinusoidal(loc_ip, concat_dim=1):
+    def encode_loc_sinusoidal(loc_ip):
         return tf.concat([
             tf.sin(loc_ip * math.pi),
             tf.cos(loc_ip * math.pi),
-        ], axis=concat_dim)
-
-   
-    @staticmethod
-    def bilinear_interpolate(loc_ip, data, remove_nans_raster=True):
-        """
-        Perform bilinear interpolation on a raster using normalized 
-        [-1, 1] lng, lat input.
-        
-        Args:
-            loc_ip: [N x 2] tensor/array of [lng, lat] in [-1, 1] space
-            data: [H x W x C] raster data
-            remove_nans_raster: whether to replace NaNs in `data` with 0.0
-        
-        Returns:
-            np.ndarray: [N x C] interpolated feats for each location
-        """
-        assert data is not None
-        assert loc_ip.shape[1] == 2
-        
-        if remove_nans_raster:
-            data = np.nan_to_num(data, nan=0.0)
-        
-        # normalize from [-1, 1] to [0, 1]
-        loc = (loc_ip + 1.0) / 2.0
-
-        # flip y-axis for raster top down layout
-        x = loc[:, 0]
-        y = 1.0 - loc[:, 1]
-    
-        # convert to pixel indices
-        px = x * (data.shape[1] - 1)
-        py = y * (data.shape[0] - 1)
-    
-        # corner integer indices
-        x0 = tf.floor(px).numpy().astype(int)
-        y0 = tf.floor(py).numpy().astype(int)
-        x1 = np.clip(x0 + 1, 0, data.shape[1] - 1)
-        y1 = np.clip(y0 + 1, 0, data.shape[0] - 1)
-
-        # deltas for interpolation
-        dx = np.expand_dims(px - x0, axis=1)
-        dy = np.expand_dims(py - y0, axis=1)
-
-        # fetch corner values
-        top_left             = data[y0, x0, :]
-        top_right            = data[y0, x1, :]
-        bottom_left          = data[y1, x0, :]
-        bottom_right         = data[y1, x1, :]
-        
-        # bilinear interpolation
-        interp_value = (
-            top_left * (1 - dx) * (1 - dy) +
-            top_right * dx * (1 - dy) + 
-            bottom_left * (1 - dx) * dy +
-            bottom_right * dx * dy
-        )
-
-        return interp_value
-
-
-
-
-
-
+        ], axis=1)

--- a/lib/inat_inferrer.py
+++ b/lib/inat_inferrer.py
@@ -37,9 +37,7 @@ class InatInferrer:
         self.setup_synonyms()
         self.setup_vision_model()
         self.setup_elevation_dataframe()
-        if config["use_coord_encoder"]:
-            self.setup_coord_encoder()
-
+        self.setup_coord_encoder()
         self.setup_geo_model()
         self.upload_folder = "static/"
 
@@ -180,17 +178,13 @@ class InatInferrer:
             elev_dfh3 = elev_dfh3.drop(columns=["lng", "lat"]).groupby(f"h3_0{resolution}").mean()
 
     def setup_coord_encoder(self):
-        raster_file = self.config["coord_encoder"]["env_raster"]
-        if raster_file is not None:
-            raster = np.load(raster_file)
-        else:
-            raster = None
-
+        self.coord_encoder = None
+        if "coord_encoder_raster" not in self.config:
+            return
+        raster = np.load(self.config["coord_encoder_raster"])
         self.coord_encoder = CoordEncoder(
-            encoding_strategy=self.config["coord_encoder"]["encoding_strategy"],
             raster=raster
         )
-
 
     def setup_geo_model(self):
         self.geo_elevation_model = None
@@ -216,7 +210,7 @@ class InatInferrer:
             print("Vision Time: %0.2fms" % ((time.time() - start_time) * 1000.))
         return results
 
-    def geo_model_predict(self, lat, lng, debug=False):
+    def geo_model_predict(self, lat, lng, encoder="h3", debug=False):
         if debug:
             start_time = time.time()
         if lat is None or lat == "" or lng is None or lng == "":
@@ -225,23 +219,23 @@ class InatInferrer:
         if self.geo_elevation_model is None:
             return None
 
-        if self.config["use_coord_encoder"]:
-            stacked_loc = np.array([[lng, lat]])
-            encoded_loc = self.coord_encoder.encode(stacked_loc)
-            geo_scores = self.geo_elevation_model.predict_encoded(encoded_loc)
-        else: 
+        geo_scores = None
+        if encoder == "h3":
             # lookup the H3 cell this lat lng occurs in
             h3_cell = h3.geo_to_h3(float(lat), float(lng), 4)
             h3_cell_centroid = h3.h3_to_geo(h3_cell)
             # get the average elevation of the above H3 cell
             elevation = self.geo_elevation_cells.loc[h3_cell].elevation
             geo_scores = self.geo_elevation_model.predict(
-                h3_cell_centroid[0], 
-                h3_cell_centroid[1], 
+                h3_cell_centroid[0],
+                h3_cell_centroid[1],
                 float(elevation)
             )
-        
-            
+        elif encoder == "raster" and self.coord_encoder is not None:
+            stacked_loc = np.array([[float(lng), float(lat)]])
+            encoded_loc = self.coord_encoder.encode(stacked_loc)
+            geo_scores = self.geo_elevation_model.predict_encoded(encoded_loc)
+
         if debug:
             print("Geo Time: %0.2fms" % ((time.time() - start_time) * 1000.))
         return geo_scores
@@ -265,9 +259,10 @@ class InatInferrer:
         image = InatInferrer.prepare_image_for_inference(file_path)
         vision_model_results = self.vision_predict(image, debug)
         raw_vision_scores = vision_model_results["predictions"]
-        raw_geo_scores = self.geo_model_predict(lat, lng, debug)
+        raw_h3_geo_scores = self.geo_model_predict(lat, lng, encoder="h3", debug=debug)
+        raw_raster_geo_scores = self.geo_model_predict(lat, lng, encoder="raster", debug=debug)
         combined_scores = self.combine_results(
-            raw_vision_scores, raw_geo_scores, filter_taxon, debug
+            raw_vision_scores, raw_h3_geo_scores, filter_taxon, raw_raster_geo_scores, debug
         )
         combined_scores = self.map_result_synonyms(combined_scores, debug)
         # for any taxon that doesn't have a geo threshold, set it to 1 which is the highest
@@ -280,7 +275,10 @@ class InatInferrer:
             "features": vision_model_results["features"]
         }
 
-    def combine_results(self, raw_vision_scores, raw_geo_scores, filter_taxon, debug=False):
+    def combine_results(
+        self, raw_vision_scores, raw_geo_scores, filter_taxon,
+        raw_raster_geo_scores=None, debug=False
+    ):
         if debug:
             start_time = time.time()
         no_geo_scores = (raw_geo_scores is None)
@@ -292,10 +290,17 @@ class InatInferrer:
         # add a column for vision scores
         leaf_scores["vision_score"] = raw_vision_scores
         # add a column for geo scores
-        leaf_scores["geo_score"] = 0 if no_geo_scores else raw_geo_scores
-        # set a lower limit for geo scores if there are any
-        leaf_scores["normalized_geo_score"] = 0 if no_geo_scores \
-            else leaf_scores["geo_score"].clip(InatInferrer.MINIMUM_GEO_SCORE, None)
+        InatInferrer.add_geo_score_column(leaf_scores, raw_geo_scores, "geo_score")
+        geo_column_for_scoring = "normalized_geo_score"
+        InatInferrer.add_geo_score_column(
+            leaf_scores, raw_raster_geo_scores, "raster_geo_score"
+        )
+        if raw_raster_geo_scores is not None:
+            # when raster geo scores are present, use them for calculating combined score
+            geo_column_for_scoring = "normalized_raster_geo_score"
+            if "use_raster_nearby" in self.config and self.config["use_raster_nearby"]:
+                leaf_scores["geo_score"] = leaf_scores["raster_geo_score"]
+                leaf_scores["normalized_geo_score"] = leaf_scores["normalized_raster_geo_score"]
 
         # if filtering by a taxon, restrict results to that taxon and its descendants
         if filter_taxon is not None:
@@ -319,7 +324,7 @@ class InatInferrer:
             # the combined score is simply the normalized vision score
             # multipliedby the normalized geo score
             leaf_scores["combined_score"] = leaf_scores["normalized_vision_score"] * \
-                leaf_scores["normalized_geo_score"]
+                leaf_scores[geo_column_for_scoring]
 
         sum_of_root_node_aggregated_combined_scores = leaf_scores["combined_score"].sum()
         if sum_of_root_node_aggregated_combined_scores > 0:
@@ -389,9 +394,14 @@ class InatInferrer:
 
         # copy columns from the already calculated leaf scores including scores
         # and class_id columns which will not be populated for synonyms in the taxonomy
-        all_node_scores = pd.merge(all_node_scores, leaf_scores[[
-            "taxon_id", "vision_score", "normalized_vision_score", "geo_score", "combined_score",
-            "normalized_geo_score", "leaf_class_id", "iconic_class_id", "spatial_class_id"]],
+        columns_to_copy = [
+            "taxon_id", "vision_score", "normalized_vision_score", "geo_score", "raster_geo_score",
+            "combined_score", "normalized_geo_score", "leaf_class_id", "iconic_class_id",
+            "spatial_class_id"
+        ]
+        all_node_scores = pd.merge(
+            all_node_scores,
+            leaf_scores[columns_to_copy],
             on="taxon_id",
             how="left",
             suffixes=["_x", None]
@@ -416,13 +426,14 @@ class InatInferrer:
 
         # loop through all results where the combined score is above the cutoff
         aggregated_scores = {}
-        for taxon_id, vision_score, geo_score, combined_score, geo_threshold in zip(
-            scores_to_aggregate["taxon_id"],
-            scores_to_aggregate["normalized_vision_score"],
-            scores_to_aggregate["geo_score"],
-            scores_to_aggregate["combined_score"],
-            scores_to_aggregate["geo_threshold"]
-        ):
+        for taxon_id, vision_score, geo_score, \
+            raster_geo_score, combined_score, geo_threshold in zip(
+                scores_to_aggregate["taxon_id"],
+                scores_to_aggregate["normalized_vision_score"],
+                scores_to_aggregate["geo_score"],
+                scores_to_aggregate["raster_geo_score"],
+                scores_to_aggregate["combined_score"],
+                scores_to_aggregate["geo_threshold"]):
             # loop through the pre-calculated ancestors of this result's taxon
             for ancestor_taxon_id in self.taxonomy.taxon_ancestors[taxon_id]:
                 # set default values for the ancestor the first time it is referenced
@@ -431,6 +442,7 @@ class InatInferrer:
                     aggregated_scores[ancestor_taxon_id]["aggregated_vision_score"] = 0
                     aggregated_scores[ancestor_taxon_id]["aggregated_combined_score"] = 0
                     aggregated_scores[ancestor_taxon_id]["aggregated_geo_score"] = 0
+                    aggregated_scores[ancestor_taxon_id]["aggregated_raster_geo_score"] = 0
                     aggregated_scores[ancestor_taxon_id][
                         "aggregated_geo_threshold"
                     ] = geo_threshold if (ancestor_taxon_id == taxon_id) else 1.0
@@ -440,7 +452,13 @@ class InatInferrer:
 
                 # aggregated geo score is the max of descendant geo scores
                 if geo_score > aggregated_scores[ancestor_taxon_id]["aggregated_geo_score"]:
-                    aggregated_scores[ancestor_taxon_id]["aggregated_geo_score"] = geo_score
+                    aggregated_scores[ancestor_taxon_id][
+                        "aggregated_geo_score"
+                    ] = geo_score
+                if geo_score > aggregated_scores[ancestor_taxon_id]["aggregated_raster_geo_score"]:
+                    aggregated_scores[ancestor_taxon_id][
+                        "aggregated_raster_geo_score"
+                    ] = raster_geo_score
 
                 # aggregated geo threshold is the min of descendant geo thresholds
                 if ancestor_taxon_id != taxon_id and geo_threshold < aggregated_scores[
@@ -749,6 +767,21 @@ class InatInferrer:
             rgb_im = im.convert("RGB")
             rgb_im.save(cache_path)
         return cache_path
+
+    @staticmethod
+    def add_geo_score_column(dataframe, raw_geo_scores, column_name="geo_score"):
+        no_geo_scores = (raw_geo_scores is None)
+        # add a column for geo scores
+        if column_name in dataframe.columns:
+            dataframe.drop(column_name, axis=1)
+        dataframe[column_name] = 0 if no_geo_scores else raw_geo_scores
+
+        # set a lower limit for geo scores if there are any
+        normalized_column_name = f"normalized_{column_name}"
+        if normalized_column_name in dataframe.columns:
+            dataframe.drop(normalized_column_name, axis=1)
+        dataframe[normalized_column_name] = 0 if no_geo_scores \
+            else dataframe[column_name].clip(InatInferrer.MINIMUM_GEO_SCORE, None)
 
     @staticmethod
     def prepare_image_for_inference(file_path):

--- a/lib/inat_vision_api.py
+++ b/lib/inat_vision_api.py
@@ -1,4 +1,3 @@
-import datetime
 import time
 import os
 import urllib
@@ -128,8 +127,6 @@ class InatVisionAPI:
         else:
             geomodel = form.geomodel.data
         if request.method == "POST" or observation_id:
-            request_start_datetime = datetime.datetime.now()
-            request_start_time = time.time()
             lat = form.lat.data
             lng = form.lng.data
             common_ancestor_rank_type = form.common_ancestor_rank_type.data

--- a/lib/inat_vision_api_responses.py
+++ b/lib/inat_vision_api_responses.py
@@ -162,6 +162,7 @@ class InatVisionAPIResponses:
         score_columns = [
             "normalized_combined_score",
             "geo_score",
+            "raster_geo_score",
             "normalized_vision_score",
             "geo_threshold"
         ]
@@ -186,6 +187,7 @@ class InatVisionAPIResponses:
             "aggregated_combined_score",
             "normalized_aggregated_combined_score",
             "aggregated_geo_score",
+            "aggregated_raster_geo_score",
             "aggregated_vision_score",
             "aggregated_geo_threshold"
         ]
@@ -199,6 +201,7 @@ class InatVisionAPIResponses:
         columns_to_return = [
             "normalized_combined_score",
             "geo_score",
+            "raster_geo_score",
             "taxon_id",
             "name",
             "normalized_vision_score",
@@ -236,6 +239,7 @@ class InatVisionAPIResponses:
             "aggregated_combined_score",
             "normalized_aggregated_combined_score",
             "aggregated_geo_score",
+            "aggregated_raster_geo_score",
             "taxon_id",
             "parent_taxon_id",
             "name",
@@ -252,6 +256,7 @@ class InatVisionAPIResponses:
             "aggregated_combined_score": "combined_score",
             "normalized_aggregated_combined_score": "normalized_combined_score",
             "aggregated_geo_score": "geo_score",
+            "aggregated_raster_geo_score": "raster_geo_score",
             "aggregated_vision_score": "vision_score",
             "aggregated_geo_threshold": "geo_threshold"
         }

--- a/lib/tf_gp_elev_model.py
+++ b/lib/tf_gp_elev_model.py
@@ -31,7 +31,6 @@ class TFGeoPriorModelElev:
         return self.gpmodel(tf.convert_to_tensor(
             tf.expand_dims(encoded_loc[0], axis=0)
         ), training=False)[0]
-        
 
     def features_for_one_class_elevation(self, latitude, longitude, elevation):
         """Evalutes the model for a single class and multiple locations

--- a/lib/tf_gp_elev_model.py
+++ b/lib/tf_gp_elev_model.py
@@ -27,6 +27,12 @@ class TFGeoPriorModelElev:
             tf.expand_dims(encoded_loc[0], axis=0)
         ), training=False)[0]
 
+    def predict_encoded(self, encoded_loc):
+        return self.gpmodel(tf.convert_to_tensor(
+            tf.expand_dims(encoded_loc[0], axis=0)
+        ), training=False)[0]
+        
+
     def features_for_one_class_elevation(self, latitude, longitude, elevation):
         """Evalutes the model for a single class and multiple locations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,8 @@ def inatInferrer(request, mocker):
         "taxon_ranges_path":
             os.path.realpath(os.path.dirname(__file__) + "/fixtures/taxon_ranges"),
         "synonyms_path":
-            os.path.realpath(os.path.dirname(__file__) + "/fixtures/synonyms.csv")
+            os.path.realpath(os.path.dirname(__file__) + "/fixtures/synonyms.csv"),
+        "use_coord_encoder": False
     }
     mocker.patch("tensorflow.keras.models.load_model", return_value=MagicMock())
     mocker.patch("tensorflow.keras.Model", return_value=MagicMock())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,7 @@ def inatInferrer(request, mocker):
         "taxon_ranges_path":
             os.path.realpath(os.path.dirname(__file__) + "/fixtures/taxon_ranges"),
         "synonyms_path":
-            os.path.realpath(os.path.dirname(__file__) + "/fixtures/synonyms.csv"),
-        "use_coord_encoder": False
+            os.path.realpath(os.path.dirname(__file__) + "/fixtures/synonyms.csv")
     }
     mocker.patch("tensorflow.keras.models.load_model", return_value=MagicMock())
     mocker.patch("tensorflow.keras.Model", return_value=MagicMock())

--- a/utils/format_elev_feats.py
+++ b/utils/format_elev_feats.py
@@ -1,0 +1,29 @@
+import tifffile
+import glob
+import numpy as np
+import os
+
+# gather tiff files
+files = ["wc2.1_5m_elev.tif"]
+
+ims = []
+for ff in files: # process into numpy array
+    im = tifffile.imread(ff)
+    im = im.astype(np.float64)
+
+    print(f"max is {np.max(im)}")
+    print(f"min is {np.min(im)}")
+
+    # normalize    
+    im[im>0] /= np.max(im)
+    im[im<0] /= np.min(im) * -1
+
+    ims.append(im)
+
+# want op to be H W C
+ims_op = np.zeros((ims[0].shape[0], ims[0].shape[1], len(ims)), dtype=np.float16)
+for ii in range(len(ims)):
+    ims_op[:,:,ii] = ims[ii].astype(np.float16)
+# save bioclimatic data as numpy array
+np.save('elev_scaled', ims_op)
+

--- a/utils/format_elev_feats.py
+++ b/utils/format_elev_feats.py
@@ -1,29 +1,26 @@
 import tifffile
-import glob
 import numpy as np
-import os
 
 # gather tiff files
 files = ["wc2.1_5m_elev.tif"]
 
 ims = []
-for ff in files: # process into numpy array
+for ff in files:  # process into numpy array
     im = tifffile.imread(ff)
     im = im.astype(np.float64)
 
     print(f"max is {np.max(im)}")
     print(f"min is {np.min(im)}")
 
-    # normalize    
-    im[im>0] /= np.max(im)
-    im[im<0] /= np.min(im) * -1
+    # normalize
+    im[im > 0] /= np.max(im)
+    im[im < 0] /= np.min(im) * -1
 
     ims.append(im)
 
 # want op to be H W C
 ims_op = np.zeros((ims[0].shape[0], ims[0].shape[1], len(ims)), dtype=np.float16)
 for ii in range(len(ims)):
-    ims_op[:,:,ii] = ims[ii].astype(np.float16)
+    ims_op[:, :, ii] = ims[ii].astype(np.float16)
 # save bioclimatic data as numpy array
-np.save('elev_scaled', ims_op)
-
+np.save("elev_scaled", ims_op)


### PR DESCRIPTION
note there are required changes to config.yml, check out config.yml.example

the current path, with centroids, requires no changes other than to mention in the config file that `use_coord_encoder` = false. I did this because I didn't want to assume you'd be ok with switching the whole coord encoding scheme to this coord encoder class, Patrick. if you're ok with it, I can migrate the existing centroid based geo prior inference and geo encoding scheme to use the CoordEncoder class throughout the repo, but that seems like more work than I wanted to take on without at least talking with you first. basically, I was trying to add the possibility of the new coordinate encoding scheme in a way that would be flexible going forward (supporting hd encodings, other env covariates, etc) while making as little impact to the existing implementation as possible. however you think I should proceed, happy to follow your direction.